### PR TITLE
Suggested improvements for WFCORE-4867

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -897,12 +897,16 @@ public class DomainModelControllerService extends AbstractControllerService impl
                     Notification notification = new Notification(ModelDescriptionConstants.BOOT_COMPLETE_NOTIFICATION, PathAddress.pathAddress(PathElement.pathElement(CORE_SERVICE, MANAGEMENT),
                             PathElement.pathElement(SERVICE, MANAGEMENT_OPERATIONS)), ControllerLogger.MGMT_OP_LOGGER.bootComplete());
                     getNotificationSupport().emit(notification);
-                    List<String> configFiles = new ArrayList<>();
+
+                    String append;
+                    String hostConfig = environment.getHostConfigurationFile().getMainFile().getName();
                     if (environment.getDomainConfigurationFile() != null) { //for slave HC is null
-                        configFiles.add(environment.getDomainConfigurationFile().getMainFile().getName());
+                        String domainConfig = environment.getDomainConfigurationFile().getMainFile().getName();
+                        append = ROOT_LOGGER.configFilesInUse(domainConfig, hostConfig);
+                    } else {
+                        append = ROOT_LOGGER.configFileInUse(hostConfig);
                     }
-                    configFiles.add(environment.getHostConfigurationFile().getMainFile().getName());
-                    bootstrapListener.printBootStatistics(true, configFiles);
+                    bootstrapListener.printBootStatistics(append);
                 }
             } else {
                 // Die!

--- a/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
@@ -1467,10 +1467,10 @@ public interface HostControllerLogger extends BasicLogger {
     ////////////////////////////////////////////////
     //Messages without IDs
 
-    @Message(id = Message.NONE, value = "Host Controller configuration files in use: %s, %s")
+    @Message(id = Message.NONE, value = "- Host Controller configuration files in use: %s, %s")
     String configFilesInUse(String domainConfigFile, String hostConfigFile);
 
-    @Message(id = Message.NONE, value = "Host Controller configuration file in use: %s")
+    @Message(id = Message.NONE, value = "- Host Controller configuration file in use: %s")
     String configFileInUse(String hostConfigFile);
 
 }

--- a/server/src/main/java/org/jboss/as/server/BootstrapListener.java
+++ b/server/src/main/java/org/jboss/as/server/BootstrapListener.java
@@ -69,7 +69,7 @@ public final class BootstrapListener {
         return monitor;
     }
 
-    public void printBootStatistics(boolean isHostController, List<String> configFiles) {
+    public void printBootStatistics(String message) {
         final StabilityStatistics statistics = new StabilityStatistics();
         try {
             monitor.awaitStability(statistics);
@@ -79,7 +79,7 @@ public final class BootstrapListener {
         } finally {
             serviceTarget.removeMonitor(monitor);
             final long bootstrapTime = System.currentTimeMillis() - startTime;
-            done(bootstrapTime, statistics, isHostController, configFiles);
+            done(bootstrapTime, statistics, message);
             monitor.clear();
         }
     }
@@ -88,7 +88,7 @@ public final class BootstrapListener {
         futureContainer.failed(new Exception(message));
     }
 
-    private void done(final long bootstrapTime, final StabilityStatistics statistics, boolean isHostController, List<String> configFiles) {
+    private void done(final long bootstrapTime, final StabilityStatistics statistics, String message) {
         futureContainer.done(serviceContainer);
         if (serviceContainer.isShutdown()) {
             // Do not print boot statistics because server
@@ -105,28 +105,12 @@ public final class BootstrapListener {
         final int problem = statistics.getProblemsCount();
         final int started = statistics.getStartedCount();
         if (failed == 0 && problem == 0) {
-            ServerLogger.AS_ROOT_LOGGER.startedClean(prettyVersion, bootstrapTime, started, active + passive + onDemand + never + lazy, onDemand + passive + lazy, getMessageToAppend(configFiles, isHostController));
+            ServerLogger.AS_ROOT_LOGGER.startedClean(prettyVersion, bootstrapTime, started, active + passive + onDemand + never + lazy, onDemand + passive + lazy, message);
             createStartupMarker("success", startTime);
         } else {
-            ServerLogger.AS_ROOT_LOGGER.startedWitErrors(prettyVersion, bootstrapTime, started, active + passive + onDemand + never + lazy, failed + problem, onDemand + passive + lazy, getMessageToAppend(configFiles, isHostController));
+            ServerLogger.AS_ROOT_LOGGER.startedWitErrors(prettyVersion, bootstrapTime, started, active + passive + onDemand + never + lazy, failed + problem, onDemand + passive + lazy, message);
             createStartupMarker("error", startTime);
         }
-    }
-
-    private String getMessageToAppend(List<String> configFiles, boolean isHostController) {
-        String append = "";
-        if (configFiles != null && !configFiles.isEmpty()) {
-            if (isHostController) {
-                if (configFiles.size() == 2) {
-                    append = ServerLogger.AS_ROOT_LOGGER.hostControllerMasterConfigFilesInUse(configFiles.get(0), configFiles.get(1));
-                } else {
-                    append = ServerLogger.AS_ROOT_LOGGER.hostControllerSlaveConfigFileInUse(configFiles.get(0));
-                }
-            } else {
-                append = ServerLogger.AS_ROOT_LOGGER.serverConfigFileInUse(configFiles.get(0));
-            }
-        }
-        return append;
     }
 
     private void createStartupMarker(String result, long startTime) {

--- a/server/src/main/java/org/jboss/as/server/ServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ServerService.java
@@ -424,11 +424,12 @@ public final class ServerService extends AbstractControllerService {
             Notification notification = new Notification(ModelDescriptionConstants.BOOT_COMPLETE_NOTIFICATION, PathAddress.pathAddress(PathElement.pathElement(CORE_SERVICE, MANAGEMENT),
                     PathElement.pathElement(SERVICE, MANAGEMENT_OPERATIONS)), ServerLogger.AS_ROOT_LOGGER.bootComplete());
             getNotificationSupport().emit(notification);
-            List<String> configFiles = new ArrayList<>();
+            String message = "";
             if (configuration.getServerEnvironment().getServerConfigurationFile() != null) {
-                configFiles.add(configuration.getServerEnvironment().getServerConfigurationFile().getMainFile().getName());
+                String serverConfig = configuration.getServerEnvironment().getServerConfigurationFile().getMainFile().getName();
+                message = ServerLogger.AS_ROOT_LOGGER.serverConfigFileInUse(serverConfig);
             }
-            bootstrapListener.printBootStatistics(false, configFiles);
+            bootstrapListener.printBootStatistics(message);
         } else {
             // Die!
             String append = "";

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -1409,12 +1409,6 @@ public interface ServerLogger extends BasicLogger {
     @Message(id = Message.NONE, value = "Adding .gitignore")
     String addingIgnored();
 
-    @Message(id = Message.NONE, value = "- Host Controller configuration files in use: %s, %s")
-    String hostControllerMasterConfigFilesInUse(String domainConfigFile, String hostConfigFile);
-
-    @Message(id = Message.NONE, value = "- Host Controller configuration files in use: %s")
-    String hostControllerSlaveConfigFileInUse(String hostConfigFile);
-
     @Message(id = Message.NONE, value = "- Server configuration file in use: %s")
     String serverConfigFileInUse(String serverConfigFile);
 }


### PR DESCRIPTION
Hello @khermano , I've just checked your changes on WFCORE-4867, and I realized we could do even better extracting the getMessageToAppend method you added recently.

Since this is quite difficult to explain on the PR itself, I've just prepared the suggestions and, if you agree, you can use them for your pull request. I'm sorry for all the back and forth on this PR that, apparently it looked simple.

Could you evaluate if you would use this improvement and share any feedback?

- Doing it we remove `hostControllerMasterConfigFilesInUse` / `hostControllerSlaveConfigFileInUse` entries from the ServerLogger. They do nothing good there because they are for a HC and not for a server.
- It simplifies a bit more the `BootstrapListener`, one error we have is we are adding to the BootstrapListener responsibilities for the HC and the Server, however, those responsibilities can be moved to the caller (ServerService / DomainModelControllerService)  